### PR TITLE
Modify file export and file naming functions

### DIFF
--- a/CommandLine/Handlers.cs
+++ b/CommandLine/Handlers.cs
@@ -11,21 +11,27 @@ public class Handlers
         string SetExport,
         string SetDatabase,
         string SetCurrency
-    ) {
-        if (SetExport != null) {
+    )
+    {
+        if (SetExport != null)
+        {
             if (Directory.Exists(SetExport))
                 SystemVariables.ExportFolder = SetExport;
             else
                 Log.Error("Export folder does not exist.");
         }
 
-        if (SetDatabase != null) {
-            if (Directory.Exists(SetDatabase)) {
+        if (SetDatabase != null)
+        {
+            if (Directory.Exists(SetDatabase))
+            {
                 string oldPath = @$"{SystemVariables.DatabaseFolder}"; // We keep the old path in case we need to revert
                 string oldPathFull = @$"{oldPath}money.db";
 
-                if (File.Exists(oldPathFull)) {
-                    try {
+                if (File.Exists(oldPathFull))
+                {
+                    try
+                    {
                         SystemVariables.DatabaseFolder = SetDatabase;
 
                         string newPath = @$"{SystemVariables.DatabaseFolder}money.db";
@@ -33,19 +39,26 @@ public class Handlers
 
                         File.Move(@$"{oldPath}money.db", newPath, true);
                         Log.Information("The database was moved successfully.");
-                    } catch (Exception) {
+                    }
+                    catch (Exception)
+                    {
                         Log.Warning("The database could not be moved.\nReverting back to the old path...");
                         SystemVariables.DatabaseFolder = oldPath;
                     }
-                } else {
+                }
+                else
+                {
                     Log.Error("The database does not exist.");
                 }
-            } else
+            }
+            else
                 Log.Error("Database folder does not exist.");
         }
 
-        if (SetCurrency != null) {
-            switch (SetCurrency) {
+        if (SetCurrency != null)
+        {
+            switch (SetCurrency)
+            {
                 case "EUR": // Euro
                     SystemVariables.Currency = "fr-FR";
                     break;
@@ -74,7 +87,8 @@ public class Handlers
         int Month,
         int Day,
         string Comment
-    ) {
+    )
+    {
         ChangeBase change = new ChangeBase()
                             .SetTitle(Title ?? string.Empty)
                             .SetAmount(Amount)
@@ -91,23 +105,33 @@ public class Handlers
 
         /* Add the change to the database
         ! Only 1 change type can be set at a time. */
-        if (Expense) {
+        if (Expense)
+        {
             Expense expense = new Expense(change);
-            try {
+            try
+            {
                 MoneyHandler.AddExpense(expense);
                 Log.Information("Expense added successfully.");
-            } catch (Exception) {
+            }
+            catch (Exception)
+            {
                 Log.Error("Could not add expense.");
             }
-        } else if (Income) {
+        }
+        else if (Income)
+        {
             Income income = new Income(change);
-            try {
+            try
+            {
                 MoneyHandler.AddIncome(income);
                 Log.Information("Income added successfully.");
-            } catch (Exception) {
+            }
+            catch (Exception)
+            {
                 Log.Error("Could not add income.");
             }
-        } else
+        }
+        else
             Log.Error("You must specify whether the change is an expense or income.");
     }
 
@@ -116,18 +140,17 @@ public class Handlers
         bool Income,
         int Month,
         int Year
-    ) {
-        if (Expense) {
-            if (!FileHandler.Export(ChangeType.Expense, Month, Year))
-                Log.Error("Could not export the expenses.");
-
+    )
+    {
+        if (Expense)
+        {
+            FileHandler.Export(ChangeType.Expense, Month, Year);
             return;
         }
 
-        if (Income) {
-            if (!FileHandler.Export(ChangeType.Income, Month, Year))
-                Log.Error("Could not export the income.");
-
+        if (Income)
+        {
+            FileHandler.Export(ChangeType.Income, Month, Year);
             return;
         }
 
@@ -139,9 +162,12 @@ public class Handlers
         bool Income,
         int Month,
         int Year
-    ) {
-        if (Expense) {
-            try {
+    )
+    {
+        if (Expense)
+        {
+            try
+            {
                 List<Expense> expenses;
 
                 // Only get the expenses that are specified by the user, or all.
@@ -154,22 +180,27 @@ public class Handlers
                 else
                     expenses = MoneyHandler.AllExpenses();
 
-                if (expenses.Count == 0) {
+                if (expenses.Count == 0)
+                {
                     Log.Warning("There are no expenses to list.");
                     return;
                 }
 
                 foreach (Expense expense in expenses)
                     Log.Information(expense.ToString("list"));
-            } catch (Exception) {
+            }
+            catch (Exception)
+            {
                 Log.Error("Could not list the expenses.");
             }
 
             return;
         }
 
-        if (Income) {
-            try {
+        if (Income)
+        {
+            try
+            {
                 List<Income> incomes;
 
                 // Only get the income that are specified by the user, or all.
@@ -182,14 +213,17 @@ public class Handlers
                 else
                     incomes = MoneyHandler.AllIncome();
 
-                if (incomes.Count == 0) {
+                if (incomes.Count == 0)
+                {
                     Log.Warning("There is no income to list.");
                     return;
                 }
 
                 foreach (Income income in incomes)
                     Log.Information(income.ToString("list"));
-            } catch (Exception) {
+            }
+            catch (Exception)
+            {
                 Log.Error("Could not list the income.");
             }
 
@@ -203,28 +237,38 @@ public class Handlers
         bool Expense,
         bool Income,
         int Id
-    ) {
-        if (Id == 0) {
+    )
+    {
+        if (Id == 0)
+        {
             Log.Error("Provide a valid ID.");
             return;
         }
 
-        if (Expense) {
-            try {
+        if (Expense)
+        {
+            try
+            {
                 MoneyHandler.RemoveExpense(Id);
                 Log.Information("Expense removed successfully.");
-            } catch (Exception) {
+            }
+            catch (Exception)
+            {
                 Log.Error("Could not remove the expense.");
             }
 
             return;
         }
 
-        if (Income) {
-            try {
+        if (Income)
+        {
+            try
+            {
                 MoneyHandler.RemoveIncome(Id);
                 Log.Information("Income removed successfully.");
-            } catch (Exception) {
+            }
+            catch (Exception)
+            {
                 Log.Error("Could not remove the income.");
             }
 

--- a/CommandLine/Handlers.cs
+++ b/CommandLine/Handlers.cs
@@ -11,27 +11,21 @@ public class Handlers
         string SetExport,
         string SetDatabase,
         string SetCurrency
-    )
-    {
-        if (SetExport != null)
-        {
+    ) {
+        if (SetExport != null) {
             if (Directory.Exists(SetExport))
                 SystemVariables.ExportFolder = SetExport;
             else
                 Log.Error("Export folder does not exist.");
         }
 
-        if (SetDatabase != null)
-        {
-            if (Directory.Exists(SetDatabase))
-            {
+        if (SetDatabase != null) {
+            if (Directory.Exists(SetDatabase)) {
                 string oldPath = @$"{SystemVariables.DatabaseFolder}"; // We keep the old path in case we need to revert
                 string oldPathFull = @$"{oldPath}money.db";
 
-                if (File.Exists(oldPathFull))
-                {
-                    try
-                    {
+                if (File.Exists(oldPathFull)) {
+                    try {
                         SystemVariables.DatabaseFolder = SetDatabase;
 
                         string newPath = @$"{SystemVariables.DatabaseFolder}money.db";
@@ -39,26 +33,19 @@ public class Handlers
 
                         File.Move(@$"{oldPath}money.db", newPath, true);
                         Log.Information("The database was moved successfully.");
-                    }
-                    catch (Exception)
-                    {
+                    } catch (Exception) {
                         Log.Warning("The database could not be moved.\nReverting back to the old path...");
                         SystemVariables.DatabaseFolder = oldPath;
                     }
-                }
-                else
-                {
+                } else {
                     Log.Error("The database does not exist.");
                 }
-            }
-            else
+            } else
                 Log.Error("Database folder does not exist.");
         }
 
-        if (SetCurrency != null)
-        {
-            switch (SetCurrency)
-            {
+        if (SetCurrency != null) {
+            switch (SetCurrency) {
                 case "EUR": // Euro
                     SystemVariables.Currency = "fr-FR";
                     break;
@@ -87,8 +74,7 @@ public class Handlers
         int Month,
         int Day,
         string Comment
-    )
-    {
+    ) {
         ChangeBase change = new ChangeBase()
                             .SetTitle(Title ?? string.Empty)
                             .SetAmount(Amount)
@@ -105,33 +91,23 @@ public class Handlers
 
         /* Add the change to the database
         ! Only 1 change type can be set at a time. */
-        if (Expense)
-        {
+        if (Expense) {
             Expense expense = new Expense(change);
-            try
-            {
+            try {
                 MoneyHandler.AddExpense(expense);
                 Log.Information("Expense added successfully.");
-            }
-            catch (Exception)
-            {
+            } catch (Exception) {
                 Log.Error("Could not add expense.");
             }
-        }
-        else if (Income)
-        {
+        } else if (Income) {
             Income income = new Income(change);
-            try
-            {
+            try {
                 MoneyHandler.AddIncome(income);
                 Log.Information("Income added successfully.");
-            }
-            catch (Exception)
-            {
+            } catch (Exception) {
                 Log.Error("Could not add income.");
             }
-        }
-        else
+        } else
             Log.Error("You must specify whether the change is an expense or income.");
     }
 
@@ -162,12 +138,9 @@ public class Handlers
         bool Income,
         int Month,
         int Year
-    )
-    {
-        if (Expense)
-        {
-            try
-            {
+    ) {
+        if (Expense) {
+            try {
                 List<Expense> expenses;
 
                 // Only get the expenses that are specified by the user, or all.
@@ -180,27 +153,22 @@ public class Handlers
                 else
                     expenses = MoneyHandler.AllExpenses();
 
-                if (expenses.Count == 0)
-                {
+                if (expenses.Count == 0) {
                     Log.Warning("There are no expenses to list.");
                     return;
                 }
 
                 foreach (Expense expense in expenses)
                     Log.Information(expense.ToString("list"));
-            }
-            catch (Exception)
-            {
+            } catch (Exception) {
                 Log.Error("Could not list the expenses.");
             }
 
             return;
         }
 
-        if (Income)
-        {
-            try
-            {
+        if (Income) {
+            try {
                 List<Income> incomes;
 
                 // Only get the income that are specified by the user, or all.
@@ -213,17 +181,14 @@ public class Handlers
                 else
                     incomes = MoneyHandler.AllIncome();
 
-                if (incomes.Count == 0)
-                {
+                if (incomes.Count == 0) {
                     Log.Warning("There is no income to list.");
                     return;
                 }
 
                 foreach (Income income in incomes)
                     Log.Information(income.ToString("list"));
-            }
-            catch (Exception)
-            {
+            } catch (Exception) {
                 Log.Error("Could not list the income.");
             }
 
@@ -237,38 +202,28 @@ public class Handlers
         bool Expense,
         bool Income,
         int Id
-    )
-    {
-        if (Id == 0)
-        {
+    ) {
+        if (Id == 0) {
             Log.Error("Provide a valid ID.");
             return;
         }
 
-        if (Expense)
-        {
-            try
-            {
+        if (Expense) {
+            try {
                 MoneyHandler.RemoveExpense(Id);
                 Log.Information("Expense removed successfully.");
-            }
-            catch (Exception)
-            {
+            } catch (Exception) {
                 Log.Error("Could not remove the expense.");
             }
 
             return;
         }
 
-        if (Income)
-        {
-            try
-            {
+        if (Income) {
+            try {
                 MoneyHandler.RemoveIncome(Id);
                 Log.Information("Income removed successfully.");
-            }
-            catch (Exception)
-            {
+            } catch (Exception) {
                 Log.Error("Could not remove the income.");
             }
 

--- a/Controllers/FileHandler.cs
+++ b/Controllers/FileHandler.cs
@@ -19,8 +19,7 @@ public class FileHandler : GenericController
     /// </summary>
     public static string CurrentFileName
     {
-        get
-        {
+        get {
             string monthFullName = DateTime.Now.ToString("MMMM");
 
             return $"{GetDate[1].ToString("00")}-{monthFullName}";
@@ -70,9 +69,9 @@ public class FileHandler : GenericController
 
                 if (!Directory.Exists(folderPath))
                 {
-                    Directory.CreateDirectory(folderPath);
-                    Log.Information("Created folder {folderPath}", folderPath);
-                }
+                Directory.CreateDirectory(folderPath);
+                Log.Information("Created folder {folderPath}", folderPath);
+            }
 
                 filename = FileName(month);
             }
@@ -125,9 +124,7 @@ public class FileHandler : GenericController
             Log.Information("Your {changeType} will be exported to {fullPath}", (changeType == ChangeType.Expense ? "expenses" : "income"), fullPath);
 
             return fullPath;
-        }
-        catch (Exception)
-        {
+        } catch (Exception) {
             return null;
         }
     }
@@ -163,7 +160,7 @@ public class FileHandler : GenericController
                     expenses = MoneyHandler.AllExpenses();
 
                 if (expenses.Count == 0)
-                {
+            {
                     Log.Warning("There are no expenses to list.");
                     return;
                 }
@@ -177,9 +174,9 @@ public class FileHandler : GenericController
 
                 outputFileContents = FileTemplates.FileTemplate(
                         changeType.ToString(),
-                        MonthIsValid(month) ? FileName(month) : CurrentFileName,
-                        total
-                    ).ToList();
+                            MonthIsValid(month) ? FileName(month) : CurrentFileName,
+                            total
+                        ).ToList();
 
                 outputFileContents = outputFileContents.Concat(outputFileContentsItems).ToList(); // Combine lists and place the header at the beginning
 
@@ -235,9 +232,9 @@ public class FileHandler : GenericController
 
                 outputFileContents = FileTemplates.FileTemplate(
                         changeType.ToString(),
-                        MonthIsValid(month) ? FileName(month) : CurrentFileName,
-                        total
-                    ).ToList();
+                            MonthIsValid(month) ? FileName(month) : CurrentFileName,
+                            total
+                        ).ToList();
 
                 outputFileContents = outputFileContents.Concat(outputFileContentsItems).ToList(); // Combine lists and place the header at the beginning
 
@@ -246,9 +243,9 @@ public class FileHandler : GenericController
                 {
                     Log.Error("Export could not be completed due to file naming error.");
                     return;
-                }
+            }
 
-                // Write the file
+            // Write the file
                 File.WriteAllLines(file, outputFileContents);
                 return;
             }
@@ -260,8 +257,3 @@ public class FileHandler : GenericController
         }
     }
 }
-
-
-
-
-

--- a/Controllers/FileHandler.cs
+++ b/Controllers/FileHandler.cs
@@ -48,7 +48,7 @@ public class FileHandler : GenericController
         {
             string categoryFolder;
             string folderPath = SystemVariables.ExportFolder; // default value only set to prevent null returns
-            string filename = "ExportedOn" + DateTime.Now.ToString("yyyyMMdd-HHmm"); // default value only set to prevent null returns
+            string filename = "ExportedOn" + DateTime.Now.ToString("yyyyMMdd-HHmm"); 
 
             switch (changeType)
             {
@@ -73,8 +73,6 @@ public class FileHandler : GenericController
                     Directory.CreateDirectory(folderPath);
                     Log.Information("Created folder {folderPath}", folderPath);
                 }
-
-                filename = FileName(month);
             }
 
             // If only specific year is specified

--- a/Controllers/FileHandler.cs
+++ b/Controllers/FileHandler.cs
@@ -47,7 +47,7 @@ public class FileHandler : GenericController
         {
             string categoryFolder;
             string folderPath = SystemVariables.ExportFolder; // default value only set to prevent null returns
-            string filename = "ExportedOn" + DateTime.Now.ToString("yyyyMMdd-HHmm");
+            string filename = "Exported_on_" + DateTime.Now.ToString("yyyy-MM-dd-HHmm");
 
             switch (changeType)
             {
@@ -63,48 +63,37 @@ public class FileHandler : GenericController
             }
 
             // If specific year and month are specified
-            if (MonthIsValid(month) && YearIsValid(year))
-            {
+            if (MonthIsValid(month) && YearIsValid(year)) {
                 folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/{year}/");
 
-                if (!Directory.Exists(folderPath))
-                {
-                Directory.CreateDirectory(folderPath);
-                Log.Information("Created folder {folderPath}", folderPath);
-                }
-            }
-
-            // If only specific year is specified
-            else if (!MonthIsValid(month) && YearIsValid(year))
-            {
-                folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/{year}/");
-
-                if (!Directory.Exists(folderPath))
-                {
+                if (!Directory.Exists(folderPath)) {
                     Directory.CreateDirectory(folderPath);
                     Log.Information("Created folder {folderPath}", folderPath);
                 }
             }
+            // If only specific year is specified
+            else if (!MonthIsValid(month) && YearIsValid(year)) {
+                folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/{year}/");
 
+                if (!Directory.Exists(folderPath)) {
+                    Directory.CreateDirectory(folderPath);
+                    Log.Information("Created folder {folderPath}", folderPath);
+                }
+            }
             // If only specific month is specified
-            else if (MonthIsValid(month) && !YearIsValid(year))
-            {
+            else if (MonthIsValid(month) && !YearIsValid(year)) {
                 folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/{FileName(month)}/");
 
-                if (!Directory.Exists(folderPath))
-                {
+                if (!Directory.Exists(folderPath)) {
                     Directory.CreateDirectory(folderPath);
                     Log.Information("Created folder {folderPath}", folderPath);
                 }
             }
-
             // If neither month or year are specified, export all table data to the root categoryFolder
-            else
-            {
+            else {
                 folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/");
 
-                if (!Directory.Exists(folderPath))
-                {
+                if (!Directory.Exists(folderPath)) {
                     Directory.CreateDirectory(folderPath);
                     Log.Information("Created folder {folderPath}", folderPath);
                 }
@@ -113,8 +102,7 @@ public class FileHandler : GenericController
             // Create the file, if it doesn't exist
             string fullPath = @$"{folderPath}{filename}.md";
 
-            if (!File.Exists(fullPath))
-            {
+            if (!File.Exists(fullPath)) {
                 File.Create(fullPath).Close();
                 Log.Information("Created file {fullPath}", fullPath);
             }

--- a/Controllers/FileHandler.cs
+++ b/Controllers/FileHandler.cs
@@ -47,7 +47,7 @@ public class FileHandler : GenericController
         {
             string categoryFolder;
             string folderPath = SystemVariables.ExportFolder; // default value only set to prevent null returns
-            string filename = "ExportedOn" + DateTime.Now.ToString("yyyyMMdd-HHmm"); // default value only set to prevent null returns
+            string filename = "ExportedOn" + DateTime.Now.ToString("yyyyMMdd-HHmm");
 
             switch (changeType)
             {
@@ -71,9 +71,7 @@ public class FileHandler : GenericController
                 {
                 Directory.CreateDirectory(folderPath);
                 Log.Information("Created folder {folderPath}", folderPath);
-            }
-
-                filename = FileName(month);
+                }
             }
 
             // If only specific year is specified

--- a/Controllers/FileHandler.cs
+++ b/Controllers/FileHandler.cs
@@ -19,7 +19,8 @@ public class FileHandler : GenericController
     /// </summary>
     public static string CurrentFileName
     {
-        get {
+        get
+        {
             string monthFullName = DateTime.Now.ToString("MMMM");
 
             return $"{GetDate[1].ToString("00")}-{monthFullName}";
@@ -43,34 +44,80 @@ public class FileHandler : GenericController
     /// </summary>
     public static string? GetFile(ChangeType changeType, int month, int year)
     {
-        try {
-            // Set the category folder
+        try
+        {
             string categoryFolder;
-            switch (changeType) {
+            string folderPath = SystemVariables.ExportFolder; // default value only set to prevent null returns
+            string filename = "ExportedOn" + DateTime.Now.ToString("yyyyMMdd-HHmm"); // default value only set to prevent null returns
+
+            switch (changeType)
+            {
                 case ChangeType.Income:
                     categoryFolder = "Income";
                     break;
-                default:
-                    categoryFolder = "Expenses";
+                case ChangeType.Expense:
+                    categoryFolder = "Expense";
                     break;
+                default:
+                    Log.Error("ChangeType enum could not be determined for file export naming.");
+                    return null;
             }
 
-            // Select the year from the input, only if it's valid
-            int chosenYear = YearIsValid(year) ? year : GetDate[2];
+            // If specific year and month are specified
+            if (MonthIsValid(month) && YearIsValid(year))
+            {
+                folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/{year}/");
 
-            // Create the folder, if it doesn't exist
-            string folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/{chosenYear}/");
-            if (!Directory.Exists(folderPath)) {
-                Directory.CreateDirectory(folderPath);
-                Log.Information("Created folder {folderPath}", folderPath);
+                if (!Directory.Exists(folderPath))
+                {
+                    Directory.CreateDirectory(folderPath);
+                    Log.Information("Created folder {folderPath}", folderPath);
+                }
+
+                filename = FileName(month);
             }
 
-            // Select the month from the input, only if it's valid
-            string fileName = MonthIsValid(month) ? FileName(month) : CurrentFileName;
+            // If only specific year is specified
+            else if (!MonthIsValid(month) && YearIsValid(year))
+            {
+                folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/{year}/");
+
+                if (!Directory.Exists(folderPath))
+                {
+                    Directory.CreateDirectory(folderPath);
+                    Log.Information("Created folder {folderPath}", folderPath);
+                }
+            }
+
+            // If only specific month is specified
+            else if (MonthIsValid(month) && !YearIsValid(year))
+            {
+                folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/{FileName(month)}/");
+
+                if (!Directory.Exists(folderPath))
+                {
+                    Directory.CreateDirectory(folderPath);
+                    Log.Information("Created folder {folderPath}", folderPath);
+                }
+            }
+
+            // If neither month or year are specified, export all table data to the root categoryFolder
+            else
+            {
+                folderPath = EnsureDirectory(@$"{SystemVariables.ExportFolder}{categoryFolder}/");
+
+                if (!Directory.Exists(folderPath))
+                {
+                    Directory.CreateDirectory(folderPath);
+                    Log.Information("Created folder {folderPath}", folderPath);
+                }
+            }
 
             // Create the file, if it doesn't exist
-            string fullPath = @$"{folderPath}{fileName}.md";
-            if (!File.Exists(fullPath)) {
+            string fullPath = @$"{folderPath}{filename}.md";
+
+            if (!File.Exists(fullPath))
+            {
                 File.Create(fullPath).Close();
                 Log.Information("Created file {fullPath}", fullPath);
             }
@@ -78,7 +125,9 @@ public class FileHandler : GenericController
             Log.Information("Your {changeType} will be exported to {fullPath}", (changeType == ChangeType.Expense ? "expenses" : "income"), fullPath);
 
             return fullPath;
-        } catch (Exception) {
+        }
+        catch (Exception)
+        {
             return null;
         }
     }
@@ -86,69 +135,133 @@ public class FileHandler : GenericController
     /// <summary>
     /// Exports all changes to the current file.
     /// </summary>
-    public static bool Export(ChangeType changeType, int month, int year)
+    /// 
+    public static void Export(ChangeType changeType, int month, int year)
     {
-        string? file = GetFile(changeType, month, year);
+        string? file;
+        List<string> outputFileContents = new List<string>();
+        List<string> outputFileContentsItems = new List<string>();
+        double total = 0;
 
-        if (file == null)
-            return false;
-
-        if (!MonthIsValid(month))
-            month = GetDate[1];
-
-        if (!YearIsValid(year))
-            year = GetDate[2];
-
-        try {
-            List<string> template;
-            double total = 0;
-
-            switch (changeType)
+        if (changeType == ChangeType.Expense)
+        {
+            try
             {
-                case ChangeType.Income:
-                    // Get total amount
-                    total = MoneyHandler.TotalMonthlyIncome(month, year);
+                List<Expense> expenses;
 
-                    // Load the file template
-                    template = FileTemplates.FileTemplate(
-                            "Income",
-                            // Select the month from the input, only if it's valid
-                            MonthIsValid(month) ? FileName(month) : CurrentFileName,
-                            total
-                        ).ToList();
+                // Only get the expenses that are specified by the user, or all.
+                if (MonthIsValid(month) && YearIsValid(year))
+                    expenses = MoneyHandler.AllMonthlyExpensesById(month, year);
 
-                    // Get all entries and add them to the list
-                    foreach (Income income in MoneyHandler.AllMonthlyIncome(month, year))
-                        template.Add(income.ToString());
+                else if (MonthIsValid(month) && !YearIsValid(year))
+                    expenses = MoneyHandler.AllExpensesOnMonth(month);
 
-                    break;
-                case ChangeType.Expense:
-                    // Get total amount
-                    total = MoneyHandler.TotalMonthlyExpenses(month, year);
+                else if (!MonthIsValid(month) && YearIsValid(year))
+                    expenses = MoneyHandler.AllExpensesOnYear(year);
 
-                    // Load the file template
-                    template = FileTemplates.FileTemplate(
-                            "Expenses",
-                            // Select the month from the input, only if it's valid
-                            MonthIsValid(month) ? FileName(month) : CurrentFileName,
-                            total
-                        ).ToList();
+                else
+                    expenses = MoneyHandler.AllExpenses();
 
-                    // Get all entries and add them to the list
-                    foreach (Expense expense in MoneyHandler.AllMonthlyExpenses(month, year))
-                        template.Add(expense.ToString());
+                if (expenses.Count == 0)
+                {
+                    Log.Warning("There are no expenses to list.");
+                    return;
+                }
 
-                    break;
-                default:
-                    return false;
+                // Get all entries and add them to the list
+                foreach (Expense expense in expenses)
+                {
+                    outputFileContentsItems.Add(expense.ToString());
+                    total += expense.Amount; //TODO: this line makes MoneyHandler.TotalMonthlyExpenses and MoneyHandler.TotalMonthlyIncome redundant (remove functions?)
+                }
+
+                outputFileContents = FileTemplates.FileTemplate(
+                        changeType.ToString(),
+                        MonthIsValid(month) ? FileName(month) : CurrentFileName,
+                        total
+                    ).ToList();
+
+                outputFileContents = outputFileContents.Concat(outputFileContentsItems).ToList(); // Combine lists and place the header at the beginning
+
+                file = GetFile(changeType, month, year); // Generate file name here so that paths are not being generated for empty result table queries
+                if (file == null)
+                {
+                    Log.Error("Export could not be completed due to file naming error.");
+                    return;
+                }
+
+                // Write the file
+                File.WriteAllLines(file, outputFileContents);
+                return;
             }
+            catch (Exception)
+            {
+                Log.Error("Error when trying to export expenses to file.");
+                return;
+            }
+        }
 
-            // Write the file
-            File.WriteAllLines(file, template);
+        if (changeType == ChangeType.Income)
+        {
+            try
+            {
+                List<Income> incomes;
 
-            return true;
-        } catch (Exception) {
-            return false;
+                // Only get the income that is specified by the user, or all.
+                if (MonthIsValid(month) && YearIsValid(year))
+                    incomes = MoneyHandler.AllMonthlyIncomeById(month, year);
+
+                else if (MonthIsValid(month) && !YearIsValid(year))
+                    incomes = MoneyHandler.AllIncomeOnMonth(month);
+
+                else if (!MonthIsValid(month) && YearIsValid(year))
+                    incomes = MoneyHandler.AllIncomeOnYear(year);
+
+                else
+                    incomes = MoneyHandler.AllIncome();
+
+                if (incomes.Count == 0)
+                {
+                    Log.Warning("There are no incomes to list.");
+                    return;
+                }
+
+                // Get all entries and add them to the list
+                foreach (Income income in incomes)
+                {
+                    outputFileContentsItems.Add(income.ToString());
+                    total += income.Amount; //TODO: this line makes MoneyHandler.TotalMonthlyExpenses and MoneyHandler.TotalMonthlyIncome redundant (remove functions?)
+                }
+
+                outputFileContents = FileTemplates.FileTemplate(
+                        changeType.ToString(),
+                        MonthIsValid(month) ? FileName(month) : CurrentFileName,
+                        total
+                    ).ToList();
+
+                outputFileContents = outputFileContents.Concat(outputFileContentsItems).ToList(); // Combine lists and place the header at the beginning
+
+                file = GetFile(changeType, month, year); // Generate file name here so that paths are not being generated for empty result table queries
+                if (file == null)
+                {
+                    Log.Error("Export could not be completed due to file naming error.");
+                    return;
+                }
+
+                // Write the file
+                File.WriteAllLines(file, outputFileContents);
+                return;
+            }
+            catch (Exception)
+            {
+                Log.Error("Error when trying to export expenses to file.");
+                return;
+            }
         }
     }
 }
+
+
+
+
+

--- a/Controllers/FileHandler.cs
+++ b/Controllers/FileHandler.cs
@@ -48,7 +48,7 @@ public class FileHandler : GenericController
         {
             string categoryFolder;
             string folderPath = SystemVariables.ExportFolder; // default value only set to prevent null returns
-            string filename = "ExportedOn" + DateTime.Now.ToString("yyyyMMdd-HHmm"); 
+            string filename = "ExportedOn" + DateTime.Now.ToString("yyyyMMdd-HHmm"); // default value only set to prevent null returns
 
             switch (changeType)
             {
@@ -73,6 +73,8 @@ public class FileHandler : GenericController
                     Directory.CreateDirectory(folderPath);
                     Log.Information("Created folder {folderPath}", folderPath);
                 }
+
+                filename = FileName(month);
             }
 
             // If only specific year is specified

--- a/Controllers/MoneyHandler.cs
+++ b/Controllers/MoneyHandler.cs
@@ -1,7 +1,6 @@
 namespace Money_CLI.Controllers;
 
 using Money_CLI.Models;
-using Money_CLI.Models.Enums;
 
 public static class MoneyHandler
 {
@@ -35,33 +34,8 @@ public static class MoneyHandler
 
     #region All monthly income and expenses
     /// <summary>
-    /// Returns a list containing all income/expenses for the specified month & year.
+    /// Returns an List containing all monthly expenses.
     /// </summary>
-    /// 
-    public static T? AllItemsById_MonthAndYear<T>(ChangeType changeType, int month, int year) where T : class //TODO: could not make this generic function example work. Instead, eliminate Income/Expense models and just use ChangeBase?
-    {
-        using (AppDbContext context = new AppDbContext())
-        {
-            switch (changeType)
-            {
-                case ChangeType.Expense:
-                    return (T)(object)context.Expenses
-                                             .Where(i => i.Month == month && i.Year == year)
-                                             .OrderBy(i => i.Id)
-                                             .ToList();
-
-                case ChangeType.Income:
-                    return (T)(object)context.Incomes
-                                             .Where(i => i.Month == month && i.Year == year)
-                                             .OrderBy(i => i.Id)
-                                             .ToList();
-                default:
-                    return default(T);
-            }
-        }
-    }
-
-
     public static List<Expense> AllMonthlyExpenses(int month, int year)
     {
         using (AppDbContext context = new AppDbContext())

--- a/Controllers/MoneyHandler.cs
+++ b/Controllers/MoneyHandler.cs
@@ -1,6 +1,7 @@
 namespace Money_CLI.Controllers;
 
 using Money_CLI.Models;
+using Money_CLI.Models.Enums;
 
 public static class MoneyHandler
 {
@@ -34,8 +35,33 @@ public static class MoneyHandler
 
     #region All monthly income and expenses
     /// <summary>
-    /// Returns an List containing all monthly expenses.
+    /// Returns a list containing all income/expenses for the specified month & year.
     /// </summary>
+    /// 
+    public static T? AllItemsById_MonthAndYear<T>(ChangeType changeType, int month, int year) where T : class //TODO: could not make this generic function example work. Instead, eliminate Income/Expense models and just use ChangeBase?
+    {
+        using (AppDbContext context = new AppDbContext())
+        {
+            switch (changeType)
+            {
+                case ChangeType.Expense:
+                    return (T)(object)context.Expenses
+                                             .Where(i => i.Month == month && i.Year == year)
+                                             .OrderBy(i => i.Id)
+                                             .ToList();
+
+                case ChangeType.Income:
+                    return (T)(object)context.Incomes
+                                             .Where(i => i.Month == month && i.Year == year)
+                                             .OrderBy(i => i.Id)
+                                             .ToList();
+                default:
+                    return default(T);
+            }
+        }
+    }
+
+
     public static List<Expense> AllMonthlyExpenses(int month, int year)
     {
         using (AppDbContext context = new AppDbContext())


### PR DESCRIPTION
Hi Stratis, here is the list of things I have included in this pull request as well as some others I am looking for your opinion on.

### Changes

- Just FYI, many of the deletes/additions are simply a result of myself using the auto-format tool within Visual Studio Community edition so these changes can be ignored. 

- Modified the FileHandler.Export to be a void function instead of a boolean

- Modified the FileHandler.Export to operate the same as the Handler.ExecuteList function (ie. query the database depending on which month/year arguments are supplied by user)

- Modified the FileHandler.GetFile function to provide unique file names (include date/time of export) as well as to save the file to a month/year/default directory depending on which month/year arguments are supplied by user

### Ideas / Looking For Comment

- I propose that we eliminate the Income and Expense models and just implement everything via the ChangeBase model. Currently, there is a lot of copy-pasted code reuse with the only difference being whether the user is working with the expense or income databases. Unless you have some future ideas that will make the Income/Expense models unique and necessary to have them as separate classes, I think it would be easier to just only use the ChangeBase model and then rework the MoneyHandler functions to take in a ChangeType argument that can then determine which table will be queried. 

> Take a look at the MoneyHandler.AllItemsById_MonthAndYear function I added for an example - I played around with trying to use generic functions while still keeping the Income/Expense models but determined that generics will not reduce the current amount of code re-use. Therefore ignore the generic aspect of this function - the main takeaway is that we could just add the ChangeType argument as a function input, then always return a List<ChangeBase> object

- It may be good to modify the GenericController.MonthIsValid & GenericController.YearIsValid checks to instead check only for a positive integer number instead of the current month/year integer checks. For example with the current implementation, if an "invalid" year of 2025 and no month is specified by the user, it will cause the entire database to be returned as the query result. Instead, if we just check for a positive integer for year and 2025 is specified, the table will be queried for items with year 2025 and return nothing (which is a more expected result from the user's point of view). Also, the assumption that years beyond the current year are invalid means that users will not be able to do future forecasting/planning ahead expenses.


Feel free to let me know if there are any things you would like changed to the code in this pull request.

Cheers,

Chris

